### PR TITLE
Place locked items that don't require logic outside of pre_fill

### DIFF
--- a/worlds/diddy_kong_racing/__init__.py
+++ b/worlds/diddy_kong_racing/__init__.py
@@ -78,6 +78,8 @@ class DiddyKongRacingWorld(World):
             set_door_unlock_requirements(self)
             place_door_unlock_items(self)
 
+        self.place_locked_items()
+
     def set_rules(self) -> None:
         set_rules(self)
 
@@ -85,7 +87,7 @@ class DiddyKongRacingWorld(World):
         self.set_track_versions()
         self.set_music()
 
-    def pre_fill(self) -> None:
+    def place_locked_items(self) -> None:
         if self.is_ffl_unused():
             future_fun_land_balloon = self.create_item(ItemName.FUTURE_FUN_LAND_BALLOON)
             for ffl_exit in self.multiworld.get_region(RegionName.FUTURE_FUN_LAND, self.player).exits:


### PR DESCRIPTION
This will prevent plando from stealing those and crashing generation +
fixes the
`test.general.test_implemented.TestImplemented.test_prefill_items` unit
test because AP didn't know about those pre_filled items due to the lack
of get_pre_fill_items